### PR TITLE
[IMP] New option 'rsnapshot_cron_file'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ rsnapshot_config_backup:
           - [backup, /usr/local/, localhost/]
 
 # rsnapshot crontab
+rsnapshot_cron_file: ansible_rsnapshot
 rsnapshot_crontab_env: {}
 rsnapshot_crontab:
     - name: hourly

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -23,7 +23,7 @@
 
 - name: Configure cron (environment variables)
   cron:
-    cron_file: ansible_rsnapshot
+    cron_file: "{{ rsnapshot_cron_file }}"
     user: "{{rsnapshot_master_host_user}}"
     name: "{{ item.key }}"
     value: "{{ item.value }}"
@@ -34,7 +34,7 @@
   cron:
     name: "{{ item.name }}"
     user: "{{rsnapshot_master_host_user}}"
-    cron_file: ansible_rsnapshot
+    cron_file: "{{ rsnapshot_cron_file }}"
     month: "{{ item.get('month', '*') }}"
     weekday: "{{ item.get('weekday', '*') }}"
     day: "{{ item.get('day', '*') }}"


### PR DESCRIPTION
 set to 'ansible_rsnapshot' by default (to generate the crontab in /etc/cron.d/ansible_rsnapshot). If unset, the cron jobs will be generated in the user's crontab.